### PR TITLE
feat: add open-ai quiz generation support

### DIFF
--- a/src/main/java/mk/ukim/finki/testcraftai/model/dto/QuizGenerationRequest.java
+++ b/src/main/java/mk/ukim/finki/testcraftai/model/dto/QuizGenerationRequest.java
@@ -1,0 +1,18 @@
+package mk.ukim.finki.testcraftai.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import mk.ukim.finki.testcraftai.model.Question;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class QuizGenerationRequest {
+    private String title;
+    private Long subjectId;
+    private int numberOfQuestions = 10;
+    private List<Question.QuestionType> questionTypes = List.of(Question.QuestionType.MULTIPLE_CHOICE, Question.QuestionType.TRUE_FALSE);
+}

--- a/src/main/java/mk/ukim/finki/testcraftai/model/dto/QuizGenerationResponse.java
+++ b/src/main/java/mk/ukim/finki/testcraftai/model/dto/QuizGenerationResponse.java
@@ -1,0 +1,33 @@
+package mk.ukim.finki.testcraftai.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import mk.ukim.finki.testcraftai.model.Question;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class QuizGenerationResponse {
+    private String title;
+    private List<QuestionDto> questions;
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class QuestionDto {
+        private String questionText;
+        private Question.QuestionType type;
+        private List<OptionDto> options;
+    }
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class OptionDto {
+        private String optionText;
+        private boolean isCorrect;
+    }
+}

--- a/src/main/java/mk/ukim/finki/testcraftai/service/OpenAIService.java
+++ b/src/main/java/mk/ukim/finki/testcraftai/service/OpenAIService.java
@@ -1,0 +1,98 @@
+package mk.ukim.finki.testcraftai.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import mk.ukim.finki.testcraftai.model.dto.QuizGenerationRequest;
+import mk.ukim.finki.testcraftai.model.dto.QuizGenerationResponse;
+import org.springframework.ai.chat.ChatClient;
+import org.springframework.ai.chat.ChatResponse;
+import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class OpenAIService {
+
+    private final ChatClient chatClient;
+    private final ObjectMapper objectMapper;
+
+    public OpenAIService(ChatClient chatClient, ObjectMapper objectMapper) {
+        this.chatClient = chatClient;
+        this.objectMapper = objectMapper;
+    }
+
+    /**
+     * Generates a quiz based on the provided text content
+     *
+     * @param content the educational content to generate questions from
+     * @param request parameters for quiz generation
+     * @return response containing generated quiz questions
+     * @throws JsonProcessingException if JSON processing fails
+     */
+    public QuizGenerationResponse generateQuiz(String content, QuizGenerationRequest request)
+            throws JsonProcessingException {
+        String promptText = buildQuizGenerationPrompt(content, request);
+
+        Prompt prompt = new Prompt(List.of(new UserMessage(promptText)));
+        ChatResponse response = chatClient.call(prompt);
+        String responseContent = response.getResult().getOutput().getContent();
+
+        return objectMapper.readValue(responseContent, QuizGenerationResponse.class);
+    }
+
+    /**
+     * Builds the prompt for quiz generation
+     *
+     * @param content the educational content
+     * @param request parameters for quiz generation
+     * @return formatted prompt text
+     */
+    private String buildQuizGenerationPrompt(String content, QuizGenerationRequest request) {
+        return String.format(
+                """
+                        You are an expert educational content creator specializing in creating quiz questions.
+                        
+                        I will provide you with educational content, and I want you to generate %d quiz questions based on this content.
+                        The quiz should focus on the most important concepts and information in the material.
+                        
+                        For each question:
+                        - Create %s type questions
+                        - Ensure questions test understanding, not just memorization
+                        - Make sure all questions are directly based on the provided content
+                        - For multiple-choice questions, provide 4 options with exactly one correct answer
+                        
+                        Return a JSON in this format:
+                        {
+                          "title": "An appropriate title for this quiz based on the content",
+                          "questions": [
+                            {
+                              "questionText": "Question text here",
+                              "type": "MULTIPLE_CHOICE",
+                              "options": [
+                                {"optionText": "Option 1", "isCorrect": false},
+                                {"optionText": "Option 2", "isCorrect": true},
+                                {"optionText": "Option 3", "isCorrect": false},
+                                {"optionText": "Option 4", "isCorrect": false}
+                              ]
+                            },
+                            {
+                              "questionText": "True/False question text here",
+                              "type": "TRUE_FALSE",
+                              "options": [
+                                {"optionText": "True", "isCorrect": true},
+                                {"optionText": "False", "isCorrect": false}
+                              ]
+                            }
+                          ]
+                        }
+                        
+                        Educational content:
+                        "%s\"""",
+                request.getNumberOfQuestions(),
+                request.getQuestionTypes().toString(),
+                content
+        );
+    }
+}


### PR DESCRIPTION
# Add OpenAI Quiz Generation Support

This PR adds end-to-end OpenAI quiz-generation support by introducing request/response DTOs and wiring up an `OpenAIService`.

---

## Changes

### DTOs

- **`QuizGenerationRequest`**  
  Carries quiz parameters:  
  - `title`  
  - `subjectId`  
  - `numberOfQuestions`  
  - `questionTypes`

- **`QuizGenerationResponse`**  
  Wraps generated quiz:  
  - `title`  
  - list of `QuestionDto`, each containing:  
    - `questionText`  
    - `type`  
    - list of nested `OptionDto` (with `optionText` and `isCorrect`)

### Service

- **`OpenAIService.generateQuiz(...)`**  
  1. Builds a structured prompt from supplied content and DTO parameters  
  2. Calls Spring’s `ChatClient` to obtain a JSON payload  
  3. Deserializes the payload into `QuizGenerationResponse` via Jackson  
  4. Encapsulates prompt-formatting logic in `buildQuizGenerationPrompt(...)`

---

## Why

- **Separation of Concerns**  
  Clear DTO boundaries keep API contracts explicit.  

- **Reusability**  
  `OpenAIService` can be injected anywhere quiz generation is needed.  

- **Testability**  
  Static DTOs and an isolated prompt builder simplify unit testing.  
