### PR TITLE
feat(subject): implement full crud for subject management

### DIFF
--- a/src/main/java/mk/ukim/finki/testcraftai/controller/SubjectController.java
+++ b/src/main/java/mk/ukim/finki/testcraftai/controller/SubjectController.java
@@ -1,0 +1,90 @@
+package mk.ukim.finki.testcraftai.controller;
+
+import lombok.RequiredArgsConstructor;
+import mk.ukim.finki.testcraftai.model.Subject;
+import mk.ukim.finki.testcraftai.service.SubjectService;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+
+import java.util.List;
+
+@Controller
+@RequestMapping("/teacher/subjects")
+@RequiredArgsConstructor
+public class SubjectController {
+
+    private final SubjectService subjectService;
+
+    @GetMapping
+    public String getSubjectsPage(Model model) {
+        List<Subject> subjects = subjectService.getAllSubjects();
+        model.addAttribute("subjects", subjects);
+        return "teacher/subjects";
+    }
+
+    @GetMapping("/create")
+    public String getCreateSubjectPage() {
+        return "teacher/create-subject";
+    }
+
+    @PostMapping("/create")
+    public String createSubject(
+            @RequestParam("name") String name,
+            @RequestParam("description") String description,
+            RedirectAttributes redirectAttributes) {
+
+        try {
+            Subject subject = subjectService.createSubject(name, description);
+            redirectAttributes.addFlashAttribute("success",
+                    "Subject '" + subject.getName() + "' created successfully!");
+            return "redirect:/teacher/subjects";
+        } catch (IllegalArgumentException e) {
+            redirectAttributes.addFlashAttribute("error", e.getMessage());
+            return "redirect:/teacher/subjects/create";
+        }
+    }
+
+    @GetMapping("/edit/{id}")
+    public String getEditSubjectPage(@PathVariable Long id, Model model) {
+        Subject subject = subjectService.getSubjectById(id)
+                .orElseThrow(() -> new IllegalArgumentException("Subject not found with ID: " + id));
+
+        model.addAttribute("subject", subject);
+        return "teacher/edit-subject";
+    }
+
+    @PostMapping("/edit/{id}")
+    public String updateSubject(
+            @PathVariable Long id,
+            @RequestParam("name") String name,
+            @RequestParam("description") String description,
+            RedirectAttributes redirectAttributes) {
+
+        try {
+            Subject subject = subjectService.updateSubject(id, name, description);
+            redirectAttributes.addFlashAttribute("success",
+                    "Subject '" + subject.getName() + "' updated successfully!");
+            return "redirect:/teacher/subjects";
+        } catch (IllegalArgumentException e) {
+            redirectAttributes.addFlashAttribute("error", e.getMessage());
+            return "redirect:/teacher/subjects/edit/" + id;
+        }
+    }
+
+    @PostMapping("/delete/{id}")
+    public String deleteSubject(
+            @PathVariable Long id,
+            RedirectAttributes redirectAttributes) {
+
+        try {
+            subjectService.deleteSubject(id);
+            redirectAttributes.addFlashAttribute("success", "Subject deleted successfully!");
+            return "redirect:/teacher/subjects";
+        } catch (IllegalArgumentException e) {
+            redirectAttributes.addFlashAttribute("error", e.getMessage());
+            return "redirect:/teacher/subjects";
+        }
+    }
+}

--- a/src/main/java/mk/ukim/finki/testcraftai/repository/SubjectRepository.java
+++ b/src/main/java/mk/ukim/finki/testcraftai/repository/SubjectRepository.java
@@ -1,0 +1,10 @@
+package mk.ukim.finki.testcraftai.repository;
+
+import mk.ukim.finki.testcraftai.model.Subject;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface SubjectRepository extends JpaRepository<Subject, Long> {
+    boolean existsByName(String name);
+}

--- a/src/main/java/mk/ukim/finki/testcraftai/service/SubjectService.java
+++ b/src/main/java/mk/ukim/finki/testcraftai/service/SubjectService.java
@@ -1,0 +1,93 @@
+package mk.ukim.finki.testcraftai.service;
+
+import lombok.RequiredArgsConstructor;
+import mk.ukim.finki.testcraftai.model.Subject;
+import mk.ukim.finki.testcraftai.repository.SubjectRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class SubjectService {
+
+    private final SubjectRepository subjectRepository;
+
+    /**
+     * Creates a new subject
+     *
+     * @param name the subject name
+     * @param description the subject description
+     * @return the created subject
+     */
+    @Transactional
+    public Subject createSubject(String name, String description) {
+        if (subjectRepository.existsByName(name)) {
+            throw new IllegalArgumentException("Subject with name '" + name + "' already exists");
+        }
+
+        Subject subject = new Subject();
+        subject.setName(name);
+        subject.setDescription(description);
+
+        return subjectRepository.save(subject);
+    }
+
+    /**
+     * Retrieves a subject by ID
+     *
+     * @param id the subject ID
+     * @return optional containing the subject if found
+     */
+    public Optional<Subject> getSubjectById(Long id) {
+        return subjectRepository.findById(id);
+    }
+
+    /**
+     * Retrieves all subjects
+     *
+     * @return list of all subjects
+     */
+    public List<Subject> getAllSubjects() {
+        return subjectRepository.findAll();
+    }
+
+    /**
+     * Updates a subject
+     *
+     * @param id the subject ID
+     * @param name the new name
+     * @param description the new description
+     * @return the updated subject
+     */
+    @Transactional
+    public Subject updateSubject(Long id, String name, String description) {
+        Subject subject = subjectRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("Subject not found with ID: " + id));
+
+        if (!subject.getName().equals(name) && subjectRepository.existsByName(name)) {
+            throw new IllegalArgumentException("Subject with name '" + name + "' already exists");
+        }
+
+        subject.setName(name);
+        subject.setDescription(description);
+
+        return subjectRepository.save(subject);
+    }
+
+    /**
+     * Deletes a subject
+     *
+     * @param id the subject ID
+     */
+    @Transactional
+    public void deleteSubject(Long id) {
+        if (!subjectRepository.existsById(id)) {
+            throw new IllegalArgumentException("Subject not found with ID: " + id);
+        }
+
+        subjectRepository.deleteById(id);
+    }
+}

--- a/src/main/resources/templates/teacher/create-subject.html
+++ b/src/main/resources/templates/teacher/create-subject.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org" xmlns:sec="http://www.thymeleaf.org/extras/spring-security">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Create Subject - TestCraft AI</title>
+</head>
+<body>
+<div th:replace="~{fragments/dashboard-layout :: html}">
+    <!-- This content will be replaced by the dashboard layout -->
+</div>
+
+<!-- Sidebar Content -->
+<div id="sidebarContent">
+    <h5 class="sidebar-heading d-flex justify-content-between align-items-center px-3 mt-4 mb-1 text-muted">
+        <span>Teacher Menu</span>
+    </h5>
+    <ul class="nav flex-column">
+        <li class="nav-item">
+            <a class="nav-link" href="/teacher/dashboard">
+                <i class="bi bi-speedometer2"></i> Dashboard
+            </a>
+        </li>
+        <li class="nav-item">
+            <a class="nav-link" href="/teacher/materials">
+                <i class="bi bi-file-earmark-text"></i> My Materials
+            </a>
+        </li>
+        <li class="nav-item">
+            <a class="nav-link" href="/teacher/quizzes">
+                <i class="bi bi-question-circle"></i> My Quizzes
+            </a>
+        </li>
+        <li class="nav-item">
+            <a class="nav-link" href="/teacher/create-quiz">
+                <i class="bi bi-plus-circle"></i> Create Quiz
+            </a>
+        </li>
+        <li class="nav-item">
+            <a class="nav-link" href="/teacher/flashcards">
+                <i class="bi bi-card-text"></i> Flashcards
+            </a>
+        </li>
+        <li class="nav-item">
+            <a class="nav-link active" href="/teacher/subjects">
+                <i class="bi bi-book"></i> Subjects
+            </a>
+        </li>
+    </ul>
+</div>
+
+<!-- Main Content -->
+<div id="mainContent">
+    <div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
+        <h1 class="h2">Create Subject</h1>
+        <div class="btn-toolbar mb-2 mb-md-0">
+            <a href="/teacher/subjects" class="btn btn-outline-secondary">
+                <i class="bi bi-arrow-left"></i> Back to Subjects
+            </a>
+        </div>
+    </div>
+
+    <div th:if="${error}" class="alert alert-danger alert-dismissible fade show" role="alert">
+        <span th:text="${error}">Error message</span>
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+    </div>
+
+    <div class="card">
+        <div class="card-body">
+            <form th:action="@{/teacher/subjects/create}" method="post">
+                <div class="mb-3">
+                    <label for="name" class="form-label">Subject Name</label>
+                    <input type="text" class="form-control" id="name" name="name" required>
+                </div>
+
+                <div class="mb-3">
+                    <label for="description" class="form-label">Description</label>
+                    <textarea class="form-control" id="description" name="description" rows="3"></textarea>
+                </div>
+
+                <div class="d-grid gap-2">
+                    <button type="submit" class="btn btn-primary">
+                        <i class="bi bi-plus-circle"></i> Create Subject
+                    </button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/teacher/edit-subject.html
+++ b/src/main/resources/templates/teacher/edit-subject.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org" xmlns:sec="http://www.thymeleaf.org/extras/spring-security">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Edit Subject - TestCraft AI</title>
+</head>
+<body>
+<div th:replace="~{fragments/dashboard-layout :: html}">
+    <!-- This content will be replaced by the dashboard layout -->
+</div>
+
+<!-- Sidebar Content -->
+<div id="sidebarContent">
+    <h5 class="sidebar-heading d-flex justify-content-between align-items-center px-3 mt-4 mb-1 text-muted">
+        <span>Teacher Menu</span>
+    </h5>
+    <ul class="nav flex-column">
+        <li class="nav-item">
+            <a class="nav-link" href="/teacher/dashboard">
+                <i class="bi bi-speedometer2"></i> Dashboard
+            </a>
+        </li>
+        <li class="nav-item">
+            <a class="nav-link" href="/teacher/materials">
+                <i class="bi bi-file-earmark-text"></i> My Materials
+            </a>
+        </li>
+        <li class="nav-item">
+            <a class="nav-link" href="/teacher/quizzes">
+                <i class="bi bi-question-circle"></i> My Quizzes
+            </a>
+        </li>
+        <li class="nav-item">
+            <a class="nav-link" href="/teacher/create-quiz">
+                <i class="bi bi-plus-circle"></i> Create Quiz
+            </a>
+        </li>
+        <li class="nav-item">
+            <a class="nav-link" href="/teacher/flashcards">
+                <i class="bi bi-card-text"></i> Flashcards
+            </a>
+        </li>
+        <li class="nav-item">
+            <a class="nav-link active" href="/teacher/subjects">
+                <i class="bi bi-book"></i> Subjects
+            </a>
+        </li>
+    </ul>
+</div>
+
+<!-- Main Content -->
+<div id="mainContent">
+    <div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
+        <h1 class="h2">Edit Subject</h1>
+        <div class="btn-toolbar mb-2 mb-md-0">
+            <a href="/teacher/subjects" class="btn btn-outline-secondary">
+                <i class="bi bi-arrow-left"></i> Back to Subjects
+            </a>
+        </div>
+    </div>
+
+    <div th:if="${error}" class="alert alert-danger alert-dismissible fade show" role="alert">
+        <span th:text="${error}">Error message</span>
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+    </div>
+
+    <div class="card">
+        <div class="card-body">
+            <form th:action="@{/teacher/subjects/edit/{id}(id=${subject.id})}" method="post">
+                <div class="mb-3">
+                    <label for="name" class="form-label">Subject Name</label>
+                    <input type="text" class="form-control" id="name" name="name" th:value="${subject.name}" required>
+                </div>
+
+                <div class="mb-3">
+                    <label for="description" class="form-label">Description</label>
+                    <textarea class="form-control" id="description" name="description" rows="3" th:text="${subject.description}"></textarea>
+                </div>
+
+                <div class="d-grid gap-2">
+                    <button type="submit" class="btn btn-primary">
+                        <i class="bi bi-save"></i> Save Changes
+                    </button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/teacher/subjects.html
+++ b/src/main/resources/templates/teacher/subjects.html
@@ -1,0 +1,130 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org" xmlns:sec="http://www.thymeleaf.org/extras/spring-security">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Subjects - TestCraft AI</title>
+</head>
+<body>
+<div th:replace="~{fragments/dashboard-layout :: html}">
+    <!-- This content will be replaced by the dashboard layout -->
+</div>
+
+<!-- Sidebar Content -->
+<div id="sidebarContent">
+    <h5 class="sidebar-heading d-flex justify-content-between align-items-center px-3 mt-4 mb-1 text-muted">
+        <span>Teacher Menu</span>
+    </h5>
+    <ul class="nav flex-column">
+        <li class="nav-item">
+            <a class="nav-link" href="/teacher/dashboard">
+                <i class="bi bi-speedometer2"></i> Dashboard
+            </a>
+        </li>
+        <li class="nav-item">
+            <a class="nav-link" href="/teacher/materials">
+                <i class="bi bi-file-earmark-text"></i> My Materials
+            </a>
+        </li>
+        <li class="nav-item">
+            <a class="nav-link" href="/teacher/quizzes">
+                <i class="bi bi-question-circle"></i> My Quizzes
+            </a>
+        </li>
+        <li class="nav-item">
+            <a class="nav-link" href="/teacher/create-quiz">
+                <i class="bi bi-plus-circle"></i> Create Quiz
+            </a>
+        </li>
+        <li class="nav-item">
+            <a class="nav-link" href="/teacher/flashcards">
+                <i class="bi bi-card-text"></i> Flashcards
+            </a>
+        </li>
+        <li class="nav-item">
+            <a class="nav-link active" href="/teacher/subjects">
+                <i class="bi bi-book"></i> Subjects
+            </a>
+        </li>
+    </ul>
+</div>
+
+<!-- Main Content -->
+<div id="mainContent">
+    <div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
+        <h1 class="h2">Subjects</h1>
+        <div class="btn-toolbar mb-2 mb-md-0">
+            <a href="/teacher/subjects/create" class="btn btn-primary">
+                <i class="bi bi-plus-circle"></i> Create Subject
+            </a>
+        </div>
+    </div>
+
+    <div th:if="${success}" class="alert alert-success alert-dismissible fade show" role="alert">
+        <span th:text="${success}">Success message</span>
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+    </div>
+
+    <div th:if="${error}" class="alert alert-danger alert-dismissible fade show" role="alert">
+        <span th:text="${error}">Error message</span>
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+    </div>
+
+    <div class="table-responsive">
+        <table class="table table-striped table-hover">
+            <thead>
+            <tr>
+                <th>Name</th>
+                <th>Description</th>
+                <th>Materials</th>
+                <th>Quizzes</th>
+                <th>Actions</th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr th:if="${subjects.isEmpty()}">
+                <td colspan="5" class="text-center">No subjects found. <a href="/teacher/subjects/create">Create your first subject</a>.</td>
+            </tr>
+            <tr th:each="subject : ${subjects}">
+                <td th:text="${subject.name}">Subject Name</td>
+                <td th:text="${subject.description}">Description</td>
+                <td th:text="${subject.materials != null ? subject.materials.size() : 0}">0</td>
+                <td th:text="${subject.quizzes != null ? subject.quizzes.size() : 0}">0</td>
+                <td>
+                    <a th:href="@{/teacher/subjects/edit/{id}(id=${subject.id})}" class="btn btn-sm btn-outline-primary">
+                        <i class="bi bi-pencil"></i> Edit
+                    </a>
+                    <button type="button" class="btn btn-sm btn-outline-danger"
+                            data-bs-toggle="modal" th:data-bs-target="${'#deleteModal-' + subject.id}">
+                        <i class="bi bi-trash"></i> Delete
+                    </button>
+
+                    <!-- Delete Confirmation Modal -->
+                    <div class="modal fade" th:id="${'deleteModal-' + subject.id}" tabindex="-1" aria-labelledby="deleteModalLabel" aria-hidden="true">
+                        <div class="modal-dialog">
+                            <div class="modal-content">
+                                <div class="modal-header">
+                                    <h5 class="modal-title" id="deleteModalLabel">Confirm Delete</h5>
+                                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                                </div>
+                                <div class="modal-body">
+                                    Are you sure you want to delete the subject <strong th:text="${subject.name}">Subject Name</strong>?
+                                    <p class="text-danger mt-2">This action cannot be undone.</p>
+                                </div>
+                                <div class="modal-footer">
+                                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                                    <form th:action="@{/teacher/subjects/delete/{id}(id=${subject.id})}" method="post">
+                                        <button type="submit" class="btn btn-danger">Delete</button>
+                                    </form>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </td>
+            </tr>
+            </tbody>
+        </table>
+    </div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
# Add Subject Management (CRUD) End-to-End

This PR delivers full subject-management functionality for teachers, including the repository, service layer, controller, and Thymeleaf UI templates.

---

## Changes

### Repository  
- **`SubjectRepository`**  
  - Extends `JpaRepository<Subject, Long>`  
  - Adds `existsByName(String name)` for duplicate-name checks

### Service  
- **`SubjectService`**  
  - `createSubject(name, description)` – throws if a subject already exists  
  - `getSubjectById(id)` and `getAllSubjects()`  
  - `updateSubject(id, name, description)` – checks for name collisions  
  - `deleteSubject(id)` – validates existence before delete  
  - Uses `@Transactional` on mutating methods

### Controller  
- **`SubjectController`**  
  - `GET /teacher/subjects` – list all subjects  
  - `GET/POST /teacher/subjects/create` – show form and handle creation  
  - `GET/POST /teacher/subjects/edit/{id}` – show form and handle updates  
  - `POST /teacher/subjects/delete/{id}` – handle deletions  
  - Uses `RedirectAttributes` for success/error flash messages

### UI Templates  
- **`teacher/subjects.html`**, **`create-subject.html`**, **`edit-subject.html`**  
  - Dashboard layout fragment include  
  - Sidebar navigation with “Subjects” active  
  - Responsive table with “No subjects” fallback  
  - Bootstrap modals for delete confirmation  
  - Create/Edit forms with validation and cancel/back links  

---

## Why

- **Separation of Concerns**  
  - Repository, service, controller, and UI are cleanly isolated.  
- **Robustness**  
  - Prevents duplicate names and handles not-found cases gracefully.  
- **UX**  
  - Consistent dashboard layout and user feedback via flash messages.
