### PR TITLE
feat(material): implement full crud and view for materials

### DIFF
--- a/src/main/java/mk/ukim/finki/testcraftai/controller/MaterialController.java
+++ b/src/main/java/mk/ukim/finki/testcraftai/controller/MaterialController.java
@@ -1,0 +1,83 @@
+package mk.ukim.finki.testcraftai.controller;
+
+import lombok.RequiredArgsConstructor;
+import mk.ukim.finki.testcraftai.model.Material;
+import mk.ukim.finki.testcraftai.model.Subject;
+import mk.ukim.finki.testcraftai.service.MaterialService;
+import mk.ukim.finki.testcraftai.service.SubjectService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+
+import java.io.IOException;
+import java.util.List;
+
+@Controller
+@RequestMapping("/teacher/materials")
+@RequiredArgsConstructor
+public class MaterialController {
+
+    private final MaterialService materialService;
+    private final SubjectService subjectService;
+
+    @GetMapping
+    public String getMaterialsPage(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size,
+            Authentication authentication,
+            Model model) {
+
+        Page<Material> materials = materialService.getMaterialsByUser(
+                authentication.getName(),
+                PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"))
+        );
+
+        model.addAttribute("materials", materials);
+        return "teacher/materials";
+    }
+
+    @GetMapping("/upload")
+    public String getUploadMaterialPage(Model model) {
+        List<Subject> subjects = subjectService.getAllSubjects();
+        model.addAttribute("subjects", subjects);
+        return "teacher/upload-material";
+    }
+
+    @PostMapping("/upload")
+    public String uploadMaterial(
+            @RequestParam("file") MultipartFile file,
+            @RequestParam("title") String title,
+            @RequestParam("subjectId") Long subjectId,
+            Authentication authentication,
+            RedirectAttributes redirectAttributes) {
+
+        try {
+            Material material = materialService.uploadMaterial(
+                    file, title, subjectId, authentication.getName()
+            );
+
+            redirectAttributes.addFlashAttribute("success",
+                    "Material '" + material.getTitle() + "' uploaded successfully!");
+            return "redirect:/teacher/materials";
+        } catch (IOException e) {
+            redirectAttributes.addFlashAttribute("error",
+                    "Failed to upload material: " + e.getMessage());
+            return "redirect:/teacher/materials/upload";
+        }
+    }
+
+    @GetMapping("/{id}")
+    public String getMaterialDetails(@PathVariable Long id, Model model) {
+        Material material = materialService.getMaterialById(id)
+                .orElseThrow(() -> new IllegalArgumentException("Material not found with ID: " + id));
+
+        model.addAttribute("material", material);
+        return "teacher/material-details";
+    }
+}

--- a/src/main/java/mk/ukim/finki/testcraftai/repository/MaterialRepository.java
+++ b/src/main/java/mk/ukim/finki/testcraftai/repository/MaterialRepository.java
@@ -1,0 +1,15 @@
+package mk.ukim.finki.testcraftai.repository;
+
+import mk.ukim.finki.testcraftai.model.Material;
+import mk.ukim.finki.testcraftai.model.Subject;
+import mk.ukim.finki.testcraftai.model.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MaterialRepository extends JpaRepository<Material, Long> {
+    Page<Material> findByUser(User user, Pageable pageable);
+    Page<Material> findBySubject(Subject subject, Pageable pageable);
+}

--- a/src/main/java/mk/ukim/finki/testcraftai/service/MaterialService.java
+++ b/src/main/java/mk/ukim/finki/testcraftai/service/MaterialService.java
@@ -1,0 +1,111 @@
+package mk.ukim.finki.testcraftai.service;
+
+import lombok.RequiredArgsConstructor;
+import mk.ukim.finki.testcraftai.model.Material;
+import mk.ukim.finki.testcraftai.model.Subject;
+import mk.ukim.finki.testcraftai.model.User;
+import mk.ukim.finki.testcraftai.repository.MaterialRepository;
+import mk.ukim.finki.testcraftai.repository.SubjectRepository;
+import mk.ukim.finki.testcraftai.repository.UserRepository;
+import mk.ukim.finki.testcraftai.util.FileProcessingUtil;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class MaterialService {
+
+    private final MaterialRepository materialRepository;
+    private final UserRepository userRepository;
+    private final SubjectRepository subjectRepository;
+
+    /**
+     * Uploads and processes a new material
+     *
+     * @param file the uploaded file
+     * @param title the title of the material
+     * @param subjectId the subject ID
+     * @param username the username of the uploader
+     * @return the saved material
+     * @throws IOException if file processing fails
+     */
+    @Transactional
+    public Material uploadMaterial(MultipartFile file, String title, Long subjectId, String username) throws IOException {
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found: " + username));
+
+        Subject subject = subjectRepository.findById(subjectId)
+                .orElseThrow(() -> new IllegalArgumentException("Subject not found with ID: " + subjectId));
+
+        // Extract text content from the file
+        String content = FileProcessingUtil.extractTextFromFile(file);
+
+        // Determine file type
+        Material.FileType fileType = FileProcessingUtil.determineFileType(file.getOriginalFilename());
+
+        // Create and save the material
+        Material material = new Material();
+        material.setTitle(title);
+        material.setContent(content);
+        material.setFileType(fileType);
+        material.setSubject(subject);
+        material.setUser(user);
+
+        return materialRepository.save(material);
+    }
+
+    /**
+     * Retrieves a material by ID
+     *
+     * @param id the material ID
+     * @return optional containing the material if found
+     */
+    public Optional<Material> getMaterialById(Long id) {
+        return materialRepository.findById(id);
+    }
+
+    /**
+     * Retrieves all materials for a user
+     *
+     * @param username the username
+     * @param pageable pagination information
+     * @return page of materials
+     */
+    public Page<Material> getMaterialsByUser(String username, Pageable pageable) {
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found: " + username));
+
+        return materialRepository.findByUser(user, pageable);
+    }
+
+    /**
+     * Retrieves all materials for a subject
+     *
+     * @param subjectId the subject ID
+     * @param pageable pagination information
+     * @return page of materials
+     */
+    public Page<Material> getMaterialsBySubject(Long subjectId, Pageable pageable) {
+        Subject subject = subjectRepository.findById(subjectId)
+                .orElseThrow(() -> new IllegalArgumentException("Subject not found with ID: " + subjectId));
+
+        return materialRepository.findBySubject(subject, pageable);
+    }
+
+    /**
+     * Retrieves all materials
+     *
+     * @return list of all materials
+     */
+    public List<Material> getAllMaterials() {
+        return materialRepository.findAll();
+    }
+}

--- a/src/main/resources/templates/teacher/material-details.html
+++ b/src/main/resources/templates/teacher/material-details.html
@@ -1,0 +1,112 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org" xmlns:sec="http://www.thymeleaf.org/extras/spring-security">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Material Details - TestCraft AI</title>
+</head>
+<body>
+<div th:replace="~{fragments/dashboard-layout :: html}">
+    <!-- This content will be replaced by the dashboard layout -->
+</div>
+
+<!-- Sidebar Content -->
+<div id="sidebarContent">
+    <h5 class="sidebar-heading d-flex justify-content-between align-items-center px-3 mt-4 mb-1 text-muted">
+        <span>Teacher Menu</span>
+    </h5>
+    <ul class="nav flex-column">
+        <li class="nav-item">
+            <a class="nav-link" href="/teacher/dashboard">
+                <i class="bi bi-speedometer2"></i> Dashboard
+            </a>
+        </li>
+        <li class="nav-item">
+            <a class="nav-link active" href="/teacher/materials">
+                <i class="bi bi-file-earmark-text"></i> My Materials
+            </a>
+        </li>
+        <li class="nav-item">
+            <a class="nav-link" href="/teacher/quizzes">
+                <i class="bi bi-question-circle"></i> My Quizzes
+            </a>
+        </li>
+        <li class="nav-item">
+            <a class="nav-link" href="/teacher/create-quiz">
+                <i class="bi bi-plus-circle"></i> Create Quiz
+            </a>
+        </li>
+        <li class="nav-item">
+            <a class="nav-link" href="/teacher/flashcards">
+                <i class="bi bi-card-text"></i> Flashcards
+            </a>
+        </li>
+        <li class="nav-item">
+            <a class="nav-link" href="/teacher/subjects">
+                <i class="bi bi-book"></i> Subjects
+            </a>
+        </li>
+    </ul>
+</div>
+
+<!-- Main Content -->
+<div id="mainContent">
+    <div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
+        <h1 class="h2" th:text="${material.title}">Material Title</h1>
+        <div class="btn-toolbar mb-2 mb-md-0">
+            <a href="/teacher/materials" class="btn btn-outline-secondary me-2">
+                <i class="bi bi-arrow-left"></i> Back to Materials
+            </a>
+            <a th:href="@{/teacher/quizzes/create(materialId=${material.id})}"
+               class="btn btn-success">
+                <i class="bi bi-plus-circle"></i> Create Quiz
+            </a>
+        </div>
+    </div>
+
+    <div class="row mb-4">
+        <div class="col-md-4">
+            <div class="card">
+                <div class="card-header">
+                    <h5 class="mb-0">Material Information</h5>
+                </div>
+                <div class="card-body">
+                    <p><strong>Subject:</strong> <span th:text="${material.subject.name}">Subject Name</span></p>
+                    <p><strong>File Type:</strong>
+                        <span th:if="${material.fileType.name() == 'PDF'}" class="badge bg-danger">PDF</span>
+                        <span th:if="${material.fileType.name() == 'DOCX'}" class="badge bg-primary">DOCX</span>
+                        <span th:if="${material.fileType.name() == 'TXT'}" class="badge bg-secondary">TXT</span>
+                    </p>
+                    <p><strong>Uploaded:</strong> <span th:text="${#temporals.format(material.createdAt, 'dd MMM yyyy HH:mm')}">01 Jan 2025 12:00</span></p>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-8">
+            <div class="card">
+                <div class="card-header">
+                    <h5 class="mb-0">Content Preview</h5>
+                </div>
+                <div class="card-body">
+                    <div class="content-preview p-3 bg-light rounded" style="max-height: 400px; overflow-y: auto;">
+                        <pre th:text="${material.content}" style="white-space: pre-wrap; font-family: inherit;">Material content goes here...</pre>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="card">
+        <div class="card-header">
+            <h5 class="mb-0">Generated Quizzes</h5>
+        </div>
+        <div class="card-body">
+            <p>No quizzes have been generated from this material yet.</p>
+            <a th:href="@{/teacher/quizzes/create(materialId=${material.id})}"
+               class="btn btn-primary">
+                <i class="bi bi-plus-circle"></i> Generate Quiz Now
+            </a>
+        </div>
+    </div>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/teacher/materials.html
+++ b/src/main/resources/templates/teacher/materials.html
@@ -1,0 +1,132 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org" xmlns:sec="http://www.thymeleaf.org/extras/spring-security">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>My Materials - TestCraft AI</title>
+</head>
+<body>
+<div th:replace="~{fragments/dashboard-layout :: html}">
+    <!-- This content will be replaced by the dashboard layout -->
+</div>
+
+<!-- Sidebar Content -->
+<div id="sidebarContent">
+    <h5 class="sidebar-heading d-flex justify-content-between align-items-center px-3 mt-4 mb-1 text-muted">
+        <span>Teacher Menu</span>
+    </h5>
+    <ul class="nav flex-column">
+        <li class="nav-item">
+            <a class="nav-link" href="/teacher/dashboard">
+                <i class="bi bi-speedometer2"></i> Dashboard
+            </a>
+        </li>
+        <li class="nav-item">
+            <a class="nav-link active" href="/teacher/materials">
+                <i class="bi bi-file-earmark-text"></i> My Materials
+            </a>
+        </li>
+        <li class="nav-item">
+            <a class="nav-link" href="/teacher/quizzes">
+                <i class="bi bi-question-circle"></i> My Quizzes
+            </a>
+        </li>
+        <li class="nav-item">
+            <a class="nav-link" href="/teacher/create-quiz">
+                <i class="bi bi-plus-circle"></i> Create Quiz
+            </a>
+        </li>
+        <li class="nav-item">
+            <a class="nav-link" href="/teacher/flashcards">
+                <i class="bi bi-card-text"></i> Flashcards
+            </a>
+        </li>
+        <li class="nav-item">
+            <a class="nav-link" href="/teacher/subjects">
+                <i class="bi bi-book"></i> Subjects
+            </a>
+        </li>
+    </ul>
+</div>
+
+<!-- Main Content -->
+<div id="mainContent">
+    <div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
+        <h1 class="h2">My Materials</h1>
+        <div class="btn-toolbar mb-2 mb-md-0">
+            <a href="/teacher/materials/upload" class="btn btn-primary">
+                <i class="bi bi-upload"></i> Upload Material
+            </a>
+        </div>
+    </div>
+
+    <div th:if="${success}" class="alert alert-success alert-dismissible fade show" role="alert">
+        <span th:text="${success}">Success message</span>
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+    </div>
+
+    <div th:if="${error}" class="alert alert-danger alert-dismissible fade show" role="alert">
+        <span th:text="${error}">Error message</span>
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+    </div>
+
+    <div class="table-responsive">
+        <table class="table table-striped table-hover">
+            <thead>
+            <tr>
+                <th>Title</th>
+                <th>Subject</th>
+                <th>File Type</th>
+                <th>Date Added</th>
+                <th>Actions</th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr th:if="${materials.isEmpty()}">
+                <td colspan="5" class="text-center">No materials found. <a href="/teacher/materials/upload">Upload your first material</a>.</td>
+            </tr>
+            <tr th:each="material : ${materials}">
+                <td th:text="${material.title}">Material Title</td>
+                <td th:text="${material.subject.name}">Subject Name</td>
+                <td>
+                    <span th:if="${material.fileType.name() == 'PDF'}" class="badge bg-danger">PDF</span>
+                    <span th:if="${material.fileType.name() == 'DOCX'}" class="badge bg-primary">DOCX</span>
+                    <span th:if="${material.fileType.name() == 'TXT'}" class="badge bg-secondary">TXT</span>
+                </td>
+                <td th:text="${#temporals.format(material.createdAt, 'dd MMM yyyy')}">01 Jan 2025</td>
+                <td>
+                    <a th:href="@{/teacher/materials/{id}(id=${material.id})}" class="btn btn-sm btn-outline-primary">
+                        <i class="bi bi-eye"></i> View
+                    </a>
+                    <a th:href="@{/teacher/quizzes/create(materialId=${material.id})}"
+                       class="btn btn-sm btn-outline-success">
+                        <i class="bi bi-plus-circle"></i> Create Quiz
+                    </a>
+
+                </td>
+            </tr>
+            </tbody>
+        </table>
+    </div>
+
+    <nav th:if="${!materials.isEmpty()}" aria-label="Page navigation">
+        <ul class="pagination justify-content-center">
+            <li class="page-item" th:classappend="${materials.first ? 'disabled' : ''}">
+                <a class="page-link" th:href="@{/teacher/materials(page=${materials.number - 1})}" aria-label="Previous">
+                    <span aria-hidden="true">&laquo;</span>
+                </a>
+            </li>
+            <li class="page-item" th:each="i : ${#numbers.sequence(0, materials.totalPages - 1)}"
+                th:classappend="${i == materials.number ? 'active' : ''}">
+                <a class="page-link" th:href="@{/teacher/materials(page=${i})}" th:text="${i + 1}">1</a>
+            </li>
+            <li class="page-item" th:classappend="${materials.last ? 'disabled' : ''}">
+                <a class="page-link" th:href="@{/teacher/materials(page=${materials.number + 1})}" aria-label="Next">
+                    <span aria-hidden="true">&raquo;</span>
+                </a>
+            </li>
+        </ul>
+    </nav>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/teacher/upload-material.html
+++ b/src/main/resources/templates/teacher/upload-material.html
@@ -1,0 +1,103 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org" xmlns:sec="http://www.thymeleaf.org/extras/spring-security">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Upload Material - TestCraft AI</title>
+</head>
+<body>
+<div th:replace="~{fragments/dashboard-layout :: html}">
+    <!-- This content will be replaced by the dashboard layout -->
+</div>
+
+<!-- Sidebar Content -->
+<div id="sidebarContent">
+    <h5 class="sidebar-heading d-flex justify-content-between align-items-center px-3 mt-4 mb-1 text-muted">
+        <span>Teacher Menu</span>
+    </h5>
+    <ul class="nav flex-column">
+        <li class="nav-item">
+            <a class="nav-link" href="/teacher/dashboard">
+                <i class="bi bi-speedometer2"></i> Dashboard
+            </a>
+        </li>
+        <li class="nav-item">
+            <a class="nav-link active" href="/teacher/materials">
+                <i class="bi bi-file-earmark-text"></i> My Materials
+            </a>
+        </li>
+        <li class="nav-item">
+            <a class="nav-link" href="/teacher/quizzes">
+                <i class="bi bi-question-circle"></i> My Quizzes
+            </a>
+        </li>
+        <li class="nav-item">
+            <a class="nav-link" href="/teacher/create-quiz">
+                <i class="bi bi-plus-circle"></i> Create Quiz
+            </a>
+        </li>
+        <li class="nav-item">
+            <a class="nav-link" href="/teacher/flashcards">
+                <i class="bi bi-card-text"></i> Flashcards
+            </a>
+        </li>
+        <li class="nav-item">
+            <a class="nav-link" href="/teacher/subjects">
+                <i class="bi bi-book"></i> Subjects
+            </a>
+        </li>
+    </ul>
+</div>
+
+<!-- Main Content -->
+<div id="mainContent">
+    <div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
+        <h1 class="h2">Upload Material</h1>
+        <div class="btn-toolbar mb-2 mb-md-0">
+            <a href="/teacher/materials" class="btn btn-outline-secondary">
+                <i class="bi bi-arrow-left"></i> Back to Materials
+            </a>
+        </div>
+    </div>
+
+    <div th:if="${error}" class="alert alert-danger alert-dismissible fade show" role="alert">
+        <span th:text="${error}">Error message</span>
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+    </div>
+
+    <div class="card">
+        <div class="card-body">
+            <form th:action="@{/teacher/materials/upload}" method="post" enctype="multipart/form-data">
+                <div class="mb-3">
+                    <label for="title" class="form-label">Material Title</label>
+                    <input type="text" class="form-control" id="title" name="title" required>
+                </div>
+
+                <div class="mb-3">
+                    <label for="subjectId" class="form-label">Subject</label>
+                    <select class="form-select" id="subjectId" name="subjectId" required>
+                        <option value="" selected disabled>Select a subject</option>
+                        <option th:each="subject : ${subjects}" th:value="${subject.id}" th:text="${subject.name}">Subject Name</option>
+                    </select>
+                    <div class="form-text">
+                        <a href="/teacher/subjects/create">Create a new subject</a> if yours is not listed.
+                    </div>
+                </div>
+
+                <div class="mb-3">
+                    <label for="file" class="form-label">Upload File</label>
+                    <input type="file" class="form-control" id="file" name="file" required accept=".pdf,.docx,.txt">
+                    <div class="form-text">Supported file types: PDF, DOCX, TXT. Maximum file size: 10MB.</div>
+                </div>
+
+                <div class="d-grid gap-2">
+                    <button type="submit" class="btn btn-primary">
+                        <i class="bi bi-upload"></i> Upload Material
+                    </button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
# Add Material Management (Upload, List, View)

This PR implements full material-management functionality for teachers, including the repository, service layer, controller, and Thymeleaf UI templates.

---

## Changes

### Repository  
- **`MaterialRepository`**  
  - Extends `JpaRepository<Material, Long>`  
  - Adds pagination methods:
    - `findByUser(User user, Pageable pageable)`  
    - `findBySubject(Subject subject, Pageable pageable)`

### Service  
- **`MaterialService`**  
  - `uploadMaterial(file, title, subjectId, username)`  
    - Extracts text via `FileProcessingUtil`  
    - Determines file type and saves metadata+content  
  - `getMaterialById(id)`  
  - `getMaterialsByUser(username, pageable)`  
  - `getMaterialsBySubject(subjectId, pageable)`  
  - `getAllMaterials()`

### Controller  
- **`MaterialController`**  
  - `GET /teacher/materials` – paginated list of uploads  
  - `GET/POST /teacher/materials/upload` – show form & handle upload  
  - `GET /teacher/materials/{id}` – detail view  
  - Uses `RedirectAttributes` for flash feedback

### UI Templates  
- **`materials.html`**, **`upload-material.html`**, **`material-details.html`**  
  - Dashboard layout and sidebar include  
  - Paginated table with “No materials” fallback  
  - Upload form with subject selector and file input  
  - Detail view with metadata card and content preview  
  - “Create Quiz” button carrying `materialId` query param  

---

## Why

- **Separation of Concerns**  
  Repository, service, controller, and UI layers are clearly separated.  
- **Scalability**  
  Pagination support ensures performance on large data sets.  
- **UX**  
  Consistent layout, clear feedback, and easy navigation between materials and quiz creation.

