### PR TITLE
feat(quiz): implement full quiz management

### DIFF
--- a/src/main/java/mk/ukim/finki/testcraftai/controller/QuizController.java
+++ b/src/main/java/mk/ukim/finki/testcraftai/controller/QuizController.java
@@ -1,0 +1,102 @@
+package mk.ukim.finki.testcraftai.controller;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import lombok.RequiredArgsConstructor;
+import mk.ukim.finki.testcraftai.model.Material;
+import mk.ukim.finki.testcraftai.model.Question;
+import mk.ukim.finki.testcraftai.model.Quiz;
+import mk.ukim.finki.testcraftai.model.Subject;
+import mk.ukim.finki.testcraftai.model.dto.QuizGenerationRequest;
+import mk.ukim.finki.testcraftai.service.MaterialService;
+import mk.ukim.finki.testcraftai.service.QuizService;
+import mk.ukim.finki.testcraftai.service.SubjectService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+
+import java.util.Arrays;
+import java.util.List;
+
+@Controller
+@RequestMapping("/teacher/quizzes")
+@RequiredArgsConstructor
+public class QuizController {
+
+    private final QuizService quizService;
+    private final MaterialService materialService;
+    private final SubjectService subjectService;
+
+    @GetMapping
+    public String getQuizzesPage(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size,
+            Authentication authentication,
+            Model model) {
+
+        Page<Quiz> quizzes = quizService.getQuizzesByUser(
+                authentication.getName(),
+                PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"))
+        );
+
+        model.addAttribute("quizzes", quizzes);
+        return "teacher/quizzes";
+    }
+
+    @GetMapping("/create")
+    public String getCreateQuizPage(Model model) {
+        List<Material> materials = materialService.getAllMaterials();
+        List<Subject> subjects = subjectService.getAllSubjects();
+        List<Question.QuestionType> questionTypes = Arrays.asList(Question.QuestionType.values());
+
+        model.addAttribute("materials", materials);
+        model.addAttribute("subjects", subjects);
+        model.addAttribute("questionTypes", questionTypes);
+        return "teacher/create-quiz";
+    }
+
+    @PostMapping("/create")
+    public String createQuiz(
+            @RequestParam("materialId") Long materialId,
+            @RequestParam("title") String title,
+            @RequestParam("subjectId") Long subjectId,
+            @RequestParam("numberOfQuestions") int numberOfQuestions,
+            @RequestParam("questionTypes") List<Question.QuestionType> questionTypes,
+            Authentication authentication,
+            RedirectAttributes redirectAttributes) {
+
+        try {
+            Material material = materialService.getMaterialById(materialId)
+                    .orElseThrow(() -> new IllegalArgumentException("Material not found with ID: " + materialId));
+
+            QuizGenerationRequest request = new QuizGenerationRequest();
+            request.setTitle(title);
+            request.setSubjectId(subjectId);
+            request.setNumberOfQuestions(numberOfQuestions);
+            request.setQuestionTypes(questionTypes);
+
+            Quiz quiz = quizService.generateQuiz(material.getContent(), request, authentication.getName());
+
+            redirectAttributes.addFlashAttribute("success",
+                    "Quiz '" + quiz.getTitle() + "' created successfully!");
+            return "redirect:/teacher/quizzes";
+        } catch (JsonProcessingException e) {
+            redirectAttributes.addFlashAttribute("error",
+                    "Failed to create quiz: " + e.getMessage());
+            return "redirect:/teacher/quizzes/create";
+        }
+    }
+
+    @GetMapping("/{id}")
+    public String getQuizDetails(@PathVariable Long id, Model model) {
+        Quiz quiz = quizService.getQuizById(id)
+                .orElseThrow(() -> new IllegalArgumentException("Quiz not found with ID: " + id));
+
+        model.addAttribute("quiz", quiz);
+        return "teacher/quiz-details";
+    }
+}

--- a/src/main/java/mk/ukim/finki/testcraftai/repository/OptionRepository.java
+++ b/src/main/java/mk/ukim/finki/testcraftai/repository/OptionRepository.java
@@ -1,0 +1,9 @@
+package mk.ukim.finki.testcraftai.repository;
+
+import mk.ukim.finki.testcraftai.model.Option;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface OptionRepository extends JpaRepository<Option, Long> {
+}

--- a/src/main/java/mk/ukim/finki/testcraftai/repository/QuestionRepository.java
+++ b/src/main/java/mk/ukim/finki/testcraftai/repository/QuestionRepository.java
@@ -1,0 +1,9 @@
+package mk.ukim.finki.testcraftai.repository;
+
+import mk.ukim.finki.testcraftai.model.Question;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface QuestionRepository extends JpaRepository<Question, Long> {
+}

--- a/src/main/java/mk/ukim/finki/testcraftai/repository/QuizRepository.java
+++ b/src/main/java/mk/ukim/finki/testcraftai/repository/QuizRepository.java
@@ -1,0 +1,15 @@
+package mk.ukim.finki.testcraftai.repository;
+
+import mk.ukim.finki.testcraftai.model.Quiz;
+import mk.ukim.finki.testcraftai.model.Subject;
+import mk.ukim.finki.testcraftai.model.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface QuizRepository extends JpaRepository<Quiz, Long> {
+    Page<Quiz> findByUser(User user, Pageable pageable);
+    Page<Quiz> findBySubject(Subject subject, Pageable pageable);
+}

--- a/src/main/java/mk/ukim/finki/testcraftai/service/QuizService.java
+++ b/src/main/java/mk/ukim/finki/testcraftai/service/QuizService.java
@@ -1,0 +1,136 @@
+package mk.ukim.finki.testcraftai.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import lombok.RequiredArgsConstructor;
+import mk.ukim.finki.testcraftai.model.*;
+import mk.ukim.finki.testcraftai.model.dto.QuizGenerationRequest;
+import mk.ukim.finki.testcraftai.model.dto.QuizGenerationResponse;
+import mk.ukim.finki.testcraftai.repository.OptionRepository;
+import mk.ukim.finki.testcraftai.repository.QuestionRepository;
+import mk.ukim.finki.testcraftai.repository.QuizRepository;
+import mk.ukim.finki.testcraftai.repository.SubjectRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class QuizService {
+
+    private final QuizRepository quizRepository;
+    private final QuestionRepository questionRepository;
+    private final OptionRepository optionRepository;
+    private final SubjectRepository subjectRepository;
+    private final UserService userService;
+    private final OpenAIService openAIService;
+
+    /**
+     * Generates a quiz from material content
+     *
+     * @param materialContent the educational content
+     * @param request quiz generation parameters
+     * @param username the username of the creator
+     * @return the created quiz
+     * @throws JsonProcessingException if JSON processing fails
+     */
+    @Transactional
+    public Quiz generateQuiz(String materialContent, QuizGenerationRequest request, String username)
+            throws JsonProcessingException {
+        User user = userService.findByUsername(username)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found: " + username));
+
+        Subject subject = subjectRepository.findById(request.getSubjectId())
+                .orElseThrow(() -> new IllegalArgumentException("Subject not found with ID: " + request.getSubjectId()));
+
+        // Generate quiz questions using OpenAI
+        QuizGenerationResponse response = openAIService.generateQuiz(materialContent, request);
+
+        // Create the quiz
+        Quiz quiz = new Quiz();
+        quiz.setTitle(response.getTitle());
+        quiz.setDescription("Generated from material content");
+        quiz.setUser(user);
+        quiz.setSubject(subject);
+        quiz.setQuestions(new ArrayList<>());
+
+        Quiz savedQuiz = quizRepository.save(quiz);
+
+        // Create questions and options
+        for (QuizGenerationResponse.QuestionDto questionDto : response.getQuestions()) {
+            Question question = new Question();
+            question.setQuestionText(questionDto.getQuestionText());
+            question.setType(questionDto.getType());
+            question.setQuiz(savedQuiz);
+            question.setOptions(new ArrayList<>());
+
+            Question savedQuestion = questionRepository.save(question);
+
+            for (QuizGenerationResponse.OptionDto optionDto : questionDto.getOptions()) {
+                Option option = new Option();
+                option.setOptionText(optionDto.getOptionText());
+                option.setCorrect(optionDto.isCorrect());
+                option.setQuestion(savedQuestion);
+
+                optionRepository.save(option);
+                savedQuestion.getOptions().add(option);
+            }
+
+            savedQuiz.getQuestions().add(savedQuestion);
+        }
+
+        return savedQuiz;
+    }
+
+    /**
+     * Retrieves a quiz by ID
+     *
+     * @param id the quiz ID
+     * @return optional containing the quiz if found
+     */
+    public Optional<Quiz> getQuizById(Long id) {
+        return quizRepository.findById(id);
+    }
+
+    /**
+     * Retrieves all quizzes for a user
+     *
+     * @param username the username
+     * @param pageable pagination information
+     * @return page of quizzes
+     */
+    public Page<Quiz> getQuizzesByUser(String username, Pageable pageable) {
+        User user = userService.findByUsername(username)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found: " + username));
+
+        return quizRepository.findByUser(user, pageable);
+    }
+
+    /**
+     * Retrieves all quizzes for a subject
+     *
+     * @param subjectId the subject ID
+     * @param pageable pagination information
+     * @return page of quizzes
+     */
+    public Page<Quiz> getQuizzesBySubject(Long subjectId, Pageable pageable) {
+        Subject subject = subjectRepository.findById(subjectId)
+                .orElseThrow(() -> new IllegalArgumentException("Subject not found with ID: " + subjectId));
+
+        return quizRepository.findBySubject(subject, pageable);
+    }
+
+    /**
+     * Retrieves all quizzes
+     *
+     * @return list of all quizzes
+     */
+    public List<Quiz> getAllQuizzes() {
+        return quizRepository.findAll();
+    }
+}

--- a/src/main/resources/templates/teacher/create-quiz.html
+++ b/src/main/resources/templates/teacher/create-quiz.html
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org" xmlns:sec="http://www.thymeleaf.org/extras/spring-security">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Create Quiz - TestCraft AI</title>
+</head>
+<body>
+<div th:replace="~{fragments/dashboard-layout :: html}">
+    <!-- This content will be replaced by the dashboard layout -->
+</div>
+
+<!-- Sidebar Content -->
+<div id="sidebarContent">
+    <h5 class="sidebar-heading d-flex justify-content-between align-items-center px-3 mt-4 mb-1 text-muted">
+        <span>Teacher Menu</span>
+    </h5>
+    <ul class="nav flex-column">
+        <li class="nav-item">
+            <a class="nav-link" href="/teacher/dashboard">
+                <i class="bi bi-speedometer2"></i> Dashboard
+            </a>
+        </li>
+        <li class="nav-item">
+            <a class="nav-link" href="/teacher/materials">
+                <i class="bi bi-file-earmark-text"></i> My Materials
+            </a>
+        </li>
+        <li class="nav-item">
+            <a class="nav-link" href="/teacher/quizzes">
+                <i class="bi bi-question-circle"></i> My Quizzes
+            </a>
+        </li>
+        <li class="nav-item">
+            <a class="nav-link active" href="/teacher/create-quiz">
+                <i class="bi bi-plus-circle"></i> Create Quiz
+            </a>
+        </li>
+        <li class="nav-item">
+            <a class="nav-link" href="/teacher/flashcards">
+                <i class="bi bi-card-text"></i> Flashcards
+            </a>
+        </li>
+        <li class="nav-item">
+            <a class="nav-link" href="/teacher/subjects">
+                <i class="bi bi-book"></i> Subjects
+            </a>
+        </li>
+    </ul>
+</div>
+
+<!-- Main Content -->
+<div id="mainContent">
+    <div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
+        <h1 class="h2">Create Quiz</h1>
+        <div class="btn-toolbar mb-2 mb-md-0">
+            <a href="/teacher/quizzes" class="btn btn-outline-secondary">
+                <i class="bi bi-arrow-left"></i> Back to Quizzes
+            </a>
+        </div>
+    </div>
+
+    <div th:if="${error}" class="alert alert-danger alert-dismissible fade show" role="alert">
+        <span th:text="${error}">Error message</span>
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+    </div>
+
+    <div class="card">
+        <div class="card-body">
+            <form th:action="@{/teacher/quizzes/create}" method="post">
+                <div class="mb-3">
+                    <label for="title" class="form-label">Quiz Title</label>
+                    <input type="text" class="form-control" id="title" name="title" required>
+                </div>
+
+                <div class="mb-3">
+                    <label for="materialId" class="form-label">Select Material</label>
+                    <select class="form-select" id="materialId" name="materialId" required>
+                        <option value="" selected disabled>Select a material</option>
+                        <option th:each="material : ${materials}" th:value="${material.id}" th:text="${material.title}">Material Title</option>
+                    </select>
+                    <div class="form-text">
+                        <a href="/teacher/materials/upload">Upload a new material</a> if yours is not listed.
+                    </div>
+                </div>
+
+                <div class="mb-3">
+                    <label for="subjectId" class="form-label">Subject</label>
+                    <select class="form-select" id="subjectId" name="subjectId" required>
+                        <option value="" selected disabled>Select a subject</option>
+                        <option th:each="subject : ${subjects}" th:value="${subject.id}" th:text="${subject.name}">Subject Name</option>
+                    </select>
+                </div>
+
+                <div class="mb-3">
+                    <label for="numberOfQuestions" class="form-label">Number of Questions</label>
+                    <input type="number" class="form-control" id="numberOfQuestions" name="numberOfQuestions" min="1" max="50" value="10" required>
+                </div>
+
+                <div class="mb-3">
+                    <label class="form-label">Question Types</label>
+                    <div class="form-check">
+                        <input class="form-check-input" type="checkbox" value="MULTIPLE_CHOICE" id="multipleChoice" name="questionTypes" checked>
+                        <label class="form-check-label" for="multipleChoice">
+                            Multiple Choice
+                        </label>
+                    </div>
+                    <div class="form-check">
+                        <input class="form-check-input" type="checkbox" value="TRUE_FALSE" id="trueFalse" name="questionTypes" checked>
+                        <label class="form-check-label" for="trueFalse">
+                            True/False
+                        </label>
+                    </div>
+                </div>
+
+                <div class="d-grid gap-2">
+                    <button type="submit" class="btn btn-primary">
+                        <i class="bi bi-magic"></i> Generate Quiz
+                    </button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/teacher/quiz-details.html
+++ b/src/main/resources/templates/teacher/quiz-details.html
@@ -1,0 +1,151 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org" xmlns:sec="http://www.thymeleaf.org/extras/spring-security">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Quiz Details - TestCraft AI</title>
+</head>
+<body>
+<div th:replace="~{fragments/dashboard-layout :: html}">
+    <!-- This content will be replaced by the dashboard layout -->
+</div>
+
+<!-- Sidebar Content -->
+<div id="sidebarContent">
+    <h5 class="sidebar-heading d-flex justify-content-between align-items-center px-3 mt-4 mb-1 text-muted">
+        <span>Teacher Menu</span>
+    </h5>
+    <ul class="nav flex-column">
+        <li class="nav-item">
+            <a class="nav-link" href="/teacher/dashboard">
+                <i class="bi bi-speedometer2"></i> Dashboard
+            </a>
+        </li>
+        <li class="nav-item">
+            <a class="nav-link" href="/teacher/materials">
+                <i class="bi bi-file-earmark-text"></i> My Materials
+            </a>
+        </li>
+        <li class="nav-item">
+            <a class="nav-link active" href="/teacher/quizzes">
+                <i class="bi bi-question-circle"></i> My Quizzes
+            </a>
+        </li>
+        <li class="nav-item">
+            <a class="nav-link" href="/teacher/create-quiz">
+                <i class="bi bi-plus-circle"></i> Create Quiz
+            </a>
+        </li>
+        <li class="nav-item">
+            <a class="nav-link" href="/teacher/flashcards">
+                <i class="bi bi-card-text"></i> Flashcards
+            </a>
+        </li>
+        <li class="nav-item">
+            <a class="nav-link" href="/teacher/subjects">
+                <i class="bi bi-book"></i> Subjects
+            </a>
+        </li>
+    </ul>
+</div>
+
+<!-- Main Content -->
+<div id="mainContent">
+    <div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
+        <h1 class="h2" th:text="${quiz.title}">Quiz Title</h1>
+        <div class="btn-toolbar mb-2 mb-md-0">
+            <a href="/teacher/quizzes" class="btn btn-outline-secondary me-2">
+                <i class="bi bi-arrow-left"></i> Back to Quizzes
+            </a>
+            <div class="btn-group">
+                <a href="#" class="btn btn-outline-primary">
+                    <i class="bi bi-download"></i> Export PDF
+                </a>
+                <a href="#" class="btn btn-outline-success">
+                    <i class="bi bi-google"></i> Create Google Form
+                </a>
+            </div>
+        </div>
+    </div>
+
+    <div class="row mb-4">
+        <div class="col-md-4">
+            <div class="card">
+                <div class="card-header">
+                    <h5 class="mb-0">Quiz Information</h5>
+                </div>
+                <div class="card-body">
+                    <p><strong>Subject:</strong> <span th:text="${quiz.subject.name}">Subject Name</span></p>
+                    <p><strong>Questions:</strong> <span th:text="${quiz.questions.size()}">10</span></p>
+                    <p><strong>Created:</strong> <span th:text="${#temporals.format(quiz.createdAt, 'dd MMM yyyy HH:mm')}">01 Jan 2025 12:00</span></p>
+                    <p th:if="${quiz.description}"><strong>Description:</strong> <span th:text="${quiz.description}">Quiz description</span></p>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-8">
+            <div class="card">
+                <div class="card-header d-flex justify-content-between align-items-center">
+                    <h5 class="mb-0">Preview</h5>
+                    <div class="form-check form-switch">
+                        <input class="form-check-input" type="checkbox" id="showAnswers" checked>
+                        <label class="form-check-label" for="showAnswers">Show Answers</label>
+                    </div>
+                </div>
+                <div class="card-body">
+                    <div class="alert alert-info">
+                        This is a preview of how the quiz will appear to students. Use the toggle to show/hide correct answers.
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="card mb-4">
+        <div class="card-header">
+            <h5 class="mb-0">Questions</h5>
+        </div>
+        <div class="card-body">
+            <div th:each="question, qStat : ${quiz.questions}" class="mb-4">
+                <div class="question-card p-3 border rounded">
+                    <h5 class="mb-3">
+                        <span th:text="${qStat.count + '. ' + question.questionText}">1. Question text goes here?</span>
+                        <span class="badge" th:classappend="${question.type.name() == 'MULTIPLE_CHOICE' ? 'bg-primary' : 'bg-success'}"
+                              th:text="${question.type.name() == 'MULTIPLE_CHOICE' ? 'Multiple Choice' : 'True/False'}">
+                                Question Type
+                            </span>
+                    </h5>
+
+                    <div class="options-list">
+                        <div th:each="option : ${question.options}" class="form-check mb-2">
+                            <input class="form-check-input" type="radio" th:name="${'question-' + question.id}" disabled>
+                            <label class="form-check-label" th:classappend="${option.isCorrect ? 'text-success fw-bold answer-correct' : ''}">
+                                <span th:text="${option.optionText}">Option text</span>
+                                <i th:if="${option.isCorrect}" class="bi bi-check-circle-fill text-success ms-2 answer-indicator"></i>
+                            </label>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<script>
+    document.addEventListener('DOMContentLoaded', function() {
+        const showAnswersToggle = document.getElementById('showAnswers');
+        const answerIndicators = document.querySelectorAll('.answer-indicator');
+        const correctAnswers = document.querySelectorAll('.answer-correct');
+
+        showAnswersToggle.addEventListener('change', function() {
+            if (this.checked) {
+                answerIndicators.forEach(el => el.style.display = 'inline');
+                correctAnswers.forEach(el => el.classList.add('text-success', 'fw-bold'));
+            } else {
+                answerIndicators.forEach(el => el.style.display = 'none');
+                correctAnswers.forEach(el => el.classList.remove('text-success', 'fw-bold'));
+            }
+        });
+    });
+</script>
+</body>
+</html>

--- a/src/main/resources/templates/teacher/quizzes.html
+++ b/src/main/resources/templates/teacher/quizzes.html
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org" xmlns:sec="http://www.thymeleaf.org/extras/spring-security">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>My Quizzes - TestCraft AI</title>
+</head>
+<body>
+<div th:replace="~{fragments/dashboard-layout :: html}">
+    <!-- This content will be replaced by the dashboard layout -->
+</div>
+
+<!-- Sidebar Content -->
+<div id="sidebarContent">
+    <h5 class="sidebar-heading d-flex justify-content-between align-items-center px-3 mt-4 mb-1 text-muted">
+        <span>Teacher Menu</span>
+    </h5>
+    <ul class="nav flex-column">
+        <li class="nav-item">
+            <a class="nav-link" href="/teacher/dashboard">
+                <i class="bi bi-speedometer2"></i> Dashboard
+            </a>
+        </li>
+        <li class="nav-item">
+            <a class="nav-link" href="/teacher/materials">
+                <i class="bi bi-file-earmark-text"></i> My Materials
+            </a>
+        </li>
+        <li class="nav-item">
+            <a class="nav-link active" href="/teacher/quizzes">
+                <i class="bi bi-question-circle"></i> My Quizzes
+            </a>
+        </li>
+        <li class="nav-item">
+            <a class="nav-link" href="/teacher/create-quiz">
+                <i class="bi bi-plus-circle"></i> Create Quiz
+            </a>
+        </li>
+        <li class="nav-item">
+            <a class="nav-link" href="/teacher/flashcards">
+                <i class="bi bi-card-text"></i> Flashcards
+            </a>
+        </li>
+        <li class="nav-item">
+            <a class="nav-link" href="/teacher/subjects">
+                <i class="bi bi-book"></i> Subjects
+            </a>
+        </li>
+    </ul>
+</div>
+
+<!-- Main Content -->
+<div id="mainContent">
+    <div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
+        <h1 class="h2">My Quizzes</h1>
+        <div class="btn-toolbar mb-2 mb-md-0">
+            <a href="/teacher/quizzes/create" class="btn btn-primary">
+                <i class="bi bi-plus-circle"></i> Create Quiz
+            </a>
+        </div>
+    </div>
+
+    <div th:if="${success}" class="alert alert-success alert-dismissible fade show" role="alert">
+        <span th:text="${success}">Success message</span>
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+    </div>
+
+    <div th:if="${error}" class="alert alert-danger alert-dismissible fade show" role="alert">
+        <span th:text="${error}">Error message</span>
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+    </div>
+
+    <div class="table-responsive">
+        <table class="table table-striped table-hover">
+            <thead>
+            <tr>
+                <th>Title</th>
+                <th>Subject</th>
+                <th>Questions</th>
+                <th>Date Created</th>
+                <th>Actions</th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr th:if="${quizzes.isEmpty()}">
+                <td colspan="5" class="text-center">No quizzes found. <a href="/teacher/quizzes/create">Create your first quiz</a>.</td>
+            </tr>
+            <tr th:each="quiz : ${quizzes}">
+                <td th:text="${quiz.title}">Quiz Title</td>
+                <td th:text="${quiz.subject.name}">Subject Name</td>
+                <td th:text="${quiz.questions.size()}">10</td>
+                <td th:text="${#temporals.format(quiz.createdAt, 'dd MMM yyyy')}">01 Jan 2025</td>
+                <td>
+                    <a th:href="@{/teacher/quizzes/{id}(id=${quiz.id})}" class="btn btn-sm btn-outline-primary">
+                        <i class="bi bi-eye"></i> View
+                    </a>
+                    <a href="#" class="btn btn-sm btn-outline-success">
+                        <i class="bi bi-download"></i> Export
+                    </a>
+                </td>
+            </tr>
+            </tbody>
+        </table>
+    </div>
+
+    <nav th:if="${!quizzes.isEmpty()}" aria-label="Page navigation">
+        <ul class="pagination justify-content-center">
+            <li class="page-item" th:classappend="${quizzes.first ? 'disabled' : ''}">
+                <a class="page-link" th:href="@{/teacher/quizzes(page=${quizzes.number - 1})}" aria-label="Previous">
+                    <span aria-hidden="true">&laquo;</span>
+                </a>
+            </li>
+            <li class="page-item" th:each="i : ${#numbers.sequence(0, quizzes.totalPages - 1)}"
+                th:classappend="${i == quizzes.number ? 'active' : ''}">
+                <a class="page-link" th:href="@{/teacher/quizzes(page=${i})}" th:text="${i + 1}">1</a>
+            </li>
+            <li class="page-item" th:classappend="${quizzes.last ? 'disabled' : ''}">
+                <a class="page-link" th:href="@{/teacher/quizzes(page=${quizzes.number + 1})}" aria-label="Next">
+                    <span aria-hidden="true">&raquo;</span>
+                </a>
+            </li>
+        </ul>
+    </nav>
+</div>
+</body>
+</html>


### PR DESCRIPTION
# Add Quiz Management (Generation, List, Detail)

This PR implements full quiz-management functionality for teachers, including repository queries, service logic for generation and persistence, controller endpoints, and Thymeleaf UI templates.

---

## Changes

### Repository  
- **`QuizRepository`**  
  - Extends `JpaRepository<Quiz, Long>`  
  - Adds pagination methods:  
    - `findByUser(User user, Pageable pageable)`  
    - `findBySubject(Subject subject, Pageable pageable)`

### Service  
- **`QuizService`**  
  - `generateQuiz(materialContent, request, username)`  
    - Fetches user & subject, calls `OpenAIService` to generate questions  
    - Persists `Quiz`, `Question`, and `Option` entities in a single transaction  
  - `getQuizById(id)`  
  - `getQuizzesByUser(username, pageable)`  
  - `getQuizzesBySubject(subjectId, pageable)`  
  - `getAllQuizzes()`

### Controller  
- **`QuizController`**  
  - `GET /teacher/quizzes` – paginated list of quizzes  
  - `GET /teacher/quizzes/create` – show generation form (materials, subjects, question types)  
  - `POST /teacher/quizzes/create` – handle quiz generation & redirect with flash messages  
  - `GET /teacher/quizzes/{id}` – quiz detail view

### UI Templates  
- **`quizzes.html`**, **`create-quiz.html`**, **`quiz-details.html`**  
  - Dashboard layout & sidebar include  
  - Paginated table with “No quizzes” fallback  
  - Quiz-generation form with material selector, parameters, and error feedback  
  - Detail page with metadata card, export buttons, and question preview with answer toggle  

---

## Why

- **Separation of Concerns**  
  Clear layering between data access, business logic, web endpoints, and views.  
- **Automation**  
  Leverages OpenAI for rapid question creation from uploaded materials.  
- **User Feedback**  
  Flash messages, toggles, and badges improve the teacher’s experience.
